### PR TITLE
fix: Fix WebSocket execution topic publishing to match frontend subsc…

### DIFF
--- a/src/main/java/com/openmanus/domain/service/ExecutionStreamPublisher.java
+++ b/src/main/java/com/openmanus/domain/service/ExecutionStreamPublisher.java
@@ -5,7 +5,7 @@ import com.openmanus.domain.model.ExecutionResultView;
 
 public interface ExecutionStreamPublisher {
 
-    void publishEvent(String sessionId, AgentExecutionEvent event);
+    void publishEvent(String topic, AgentExecutionEvent event);
 
-    void publishResult(String sessionId, ExecutionResultView result);
+    void publishResult(String topic, ExecutionResultView result);
 }

--- a/src/main/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisher.java
+++ b/src/main/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisher.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 @Component
 public class WebSocketExecutionStreamPublisher implements ExecutionStreamPublisher {
-
-    private static final String EXECUTION_TOPIC_PREFIX = "/topic/executions/";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     private final SimpMessagingTemplate messagingTemplate;
@@ -24,22 +22,22 @@ public class WebSocketExecutionStreamPublisher implements ExecutionStreamPublish
     }
 
     @Override
-    public void publishEvent(String sessionId, AgentExecutionEvent event) {
-        messagingTemplate.convertAndSend(EXECUTION_TOPIC_PREFIX + sessionId, event);
-        publishThoughtLog(sessionId, event);
+    public void publishEvent(String topic, AgentExecutionEvent event) {
+        messagingTemplate.convertAndSend(topic, event);
+        publishThoughtLog(topic, event);
     }
 
     @Override
-    public void publishResult(String sessionId, ExecutionResultView result) {
-        messagingTemplate.convertAndSend(EXECUTION_TOPIC_PREFIX + sessionId + "/result", result);
+    public void publishResult(String topic, ExecutionResultView result) {
+        messagingTemplate.convertAndSend(topic + "/result", result);
     }
 
-    private void publishThoughtLog(String sessionId, AgentExecutionEvent event) {
+    private void publishThoughtLog(String topic, AgentExecutionEvent event) {
         String message = formatThoughtMessage(event);
         if (message == null || message.isBlank()) {
             return;
         }
-        messagingTemplate.convertAndSend(EXECUTION_TOPIC_PREFIX + sessionId + "/logs", logPayload(sessionId, message));
+        messagingTemplate.convertAndSend(topic + "/logs", logPayload(event == null ? null : event.getSessionId(), message));
     }
 
     private String formatThoughtMessage(AgentExecutionEvent event) {

--- a/src/test/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisherTest.java
+++ b/src/test/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisherTest.java
@@ -1,6 +1,7 @@
 package com.openmanus.infra.monitoring;
 
 import com.openmanus.domain.model.AgentExecutionEvent;
+import com.openmanus.domain.model.ExecutionResultView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -15,6 +16,8 @@ import static org.mockito.Mockito.verify;
 @DisplayName("WebSocketExecutionStreamPublisher Tests")
 class WebSocketExecutionStreamPublisherTest {
 
+    private static final String TOPIC = "/topic/executions/session-1/execution-1";
+
     private final SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
     private final WebSocketExecutionStreamPublisher publisher = new WebSocketExecutionStreamPublisher(messagingTemplate);
 
@@ -27,10 +30,10 @@ class WebSocketExecutionStreamPublisherTest {
                 .input("think about next step")
                 .build();
 
-        publisher.publishEvent("session-1/execution-1", event);
+        publisher.publishEvent(TOPIC, event);
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/executions/session-1/execution-1/logs"),
+                eq(TOPIC + "/logs"),
                 (Object) argThat(payload -> hasLogMessage(payload, "模型请求\nthink about next step"))
         );
     }
@@ -46,11 +49,29 @@ class WebSocketExecutionStreamPublisherTest {
                 .status("ERROR")
                 .build();
 
-        publisher.publishEvent("session-1/execution-1", event);
+        publisher.publishEvent(TOPIC, event);
 
         verify(messagingTemplate).convertAndSend(
-                eq("/topic/executions/session-1/execution-1/logs"),
+                eq(TOPIC + "/logs"),
                 (Object) argThat(payload -> hasLogMessage(payload, "执行完成\n执行出错: boom"))
+        );
+    }
+
+    @Test
+    @DisplayName("should publish final result to matching execution topic")
+    void shouldPublishFinalResultToMatchingExecutionTopic() {
+        ExecutionResultView result = ExecutionResultView.builder()
+                .sessionId("session-1")
+                .result("hello")
+                .status("SUCCESS")
+                .build();
+
+        publisher.publishResult(TOPIC, result);
+
+        verify(messagingTemplate).convertAndSend(
+                eq(TOPIC + "/result"),
+                argThat(payload -> payload instanceof ExecutionResultView view
+                        && "hello".equals(view.getResult()))
         );
     }
 


### PR DESCRIPTION
## Pull Request 描述

修复执行流 WebSocket 主题地址不一致的问题，解决后端已经产生执行结果，但前端仍停留在 `Waiting for backend events...` 的现象。

### 更改类型

- [x] Bug修复 (non-breaking change which fixes an issue)
- [ ] 新功能 (non-breaking change which adds functionality)
- [ ] 破坏性更改 (fix or feature that would cause existing functionality to not work as expected)
- [ ] 文档更新 (documentation only changes)
- [ ] 代码重构 (refactoring existing code without changing functionality)
- [ ] 性能优化 (performance improvements)
- [x] 测试改进 (adding missing tests or correcting existing tests)

### 相关Issue

关闭 #请填写对应 issue 编号

### 更改详情

本次修改修复了执行流 WebSocket 发布地址与前端订阅地址不一致的问题。

在当前执行链路中，后端 `/api/agent/workflow-stream` 会返回完整的执行主题，例如：

`/topic/executions/{sessionId}/{executionId}`

前端会基于该 `topic` 订阅：

- `${topic}`
- `${topic}/logs`
- `${topic}/result`

但原实现中，`WebSocketExecutionStreamPublisher` 在发布事件、日志和结果时，又额外拼接了一层 `/topic/executions/` 前缀，导致后端实际发布地址与前端订阅地址不一致。因此即使后端日志中已经出现 LLM 返回内容和执行完成记录，前端仍无法收到对应消息。

本次修改包括：

- 将 `ExecutionStreamPublisher` 接口中的参数语义从 `sessionId` 调整为完整 `topic`
- 修改 `WebSocketExecutionStreamPublisher`，直接使用服务层传入的完整 `topic` 发布消息
- 保持日志和结果主题的拼接规则与前端订阅逻辑一致
- 更新并补充测试，覆盖日志主题和最终结果主题的发布行为

涉及文件：

- `src/main/java/com/openmanus/domain/service/ExecutionStreamPublisher.java`
- `src/main/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisher.java`
- `src/test/java/com/openmanus/infra/monitoring/WebSocketExecutionStreamPublisherTest.java`

### 测试

请描述您为验证更改而运行的测试。

- [ ] 单元测试
- [ ] 集成测试
- [x] 手动测试

**测试配置**:
* Java版本：23
* 操作系统：Windows
* Docker版本（如果适用）：Docker Desktop 4.48.0

补充说明：

- 已执行编译验证：
  `mvn -DskipTests -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djacoco.skip=true compile`
- 编译通过
- 手动验证场景为：后端日志已产生 LLM 响应内容时，前端应能够收到对应执行流消息，而不是持续停留在等待状态

如果你想更保守一点，也可以把 Java 版本改成你本机实际跑这个项目时显示的版本。

### 检查清单

- [x] 我的代码遵循了项目的代码风格指南
- [x] 我已经进行了自我审查
- [ ] 我已经添加了注释，特别是在难以理解的部分
- [ ] 我已经相应地更改了文档
- [x] 我的更改没有产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能有效的测试
- [ ] 新的和现有的单元测试都通过了我的更改
- [ ] 任何依赖的更改都已合并并发布

这里有两项我故意没帮你勾：
- `新的和现有的单元测试都通过了我的更改`
- `我已经相应地更改了文档`

因为我们这次主要做了编译验证和手动验证，没有完整跑通现有测试集；文档也确实没改。这样写更诚实，也更安全。

### 截图（如果适用）

无

如果你后面能截到“修改前前端卡住 / 修改后前端显示回复”的对比图，也可以补上。

### 额外的上下文

该问题表现为：

- 后端控制台已经出现 `llm_response` 和执行完成日志
- 前端仍显示 `Waiting for backend events...`
- 根因是后端 WebSocket 发布地址与前端基于接口返回值订阅的地址不一致

本次修复仅调整 WebSocket 执行流主题的发布逻辑，不涉及 Docker 兼容性或其他平台相关逻辑。

### 审查者注意事项

请特别注意以下方面：

- [x] 代码质量和可读性
- [ ] 性能影响
- [ ] 安全性考虑
- [x] 向后兼容性
- [x] 测试覆盖率

这里之所以勾 `向后兼容性`，是因为这次改动本质上是在让发布地址和既有接口返回值保持一致，没有引入新的协议格式。

---

**审查清单（审查者填写）：**

- [ ] 代码审查完成
- [ ] 测试通过
- [ ] 文档审查（如果适用）
- [ ] 性能评估（如果适用）
- [ ] 安全审查（如果适用）